### PR TITLE
feature Hadolint 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build-graph-updater:
 	$(CONTAINER_RUNTIME) build ./graph-updater/ -t localhost/$(APP_NAME)-graph-updater:$(APP_VERSION)
 
 kind-push-all: 
-	kind load docker-image localhost/$(APP_NAME)-api:$(APP_VERSION)
+	kind load docker-image localhost/$(APP_NAME)-graphql-api:$(APP_VERSION)
 	kind load docker-image localhost/$(APP_NAME)-web-endpoint-scanner:$(APP_VERSION)
 	kind load docker-image localhost/$(APP_NAME)-cloned-repo-scanner:$(APP_VERSION)
 	kind load docker-image localhost/$(APP_NAME)-octokit-scanner:$(APP_VERSION)

--- a/api/src/.env.example
+++ b/api/src/.env.example
@@ -1,4 +1,4 @@
-GRAPHQL_HOST="127.0.0.1"
+GRAPHQL_HOST="0.0.0.0"
 GRAPHQL_PORT="4000"
 
 DB_HOST="http://example-simple-single-ea:8529"

--- a/api/src/graphql_types/input_types.py
+++ b/api/src/graphql_types/input_types.py
@@ -32,7 +32,8 @@ class GithubEndpointInput:
     branch_protection: Optional[CheckPassesInput] = None
     has_security_md: Optional[CheckPassesInput] = None
     has_dependabot_yaml: Optional[CheckPassesInput] = None
-    gitleaks: Optional[CheckPassesInput] = None                                      
+    gitleaks: Optional[CheckPassesInput] = None  
+    hadolint: Optional[CheckPassesInput] = None                                        
 
 
 @strawberry.input

--- a/api/src/graphql_types/typedef.py
+++ b/api/src/graphql_types/typedef.py
@@ -42,6 +42,7 @@ class GithubEndpoint(Endpoint):
     has_security_md: CheckPasses
     has_dependabot_yaml: CheckPasses
     gitleaks: CheckPasses
+    hadolint: CheckPassess
 
 @strawberry.type
 class Accessibility:

--- a/api/src/graphql_types/typedef.py
+++ b/api/src/graphql_types/typedef.py
@@ -42,7 +42,7 @@ class GithubEndpoint(Endpoint):
     has_security_md: CheckPasses
     has_dependabot_yaml: CheckPasses
     gitleaks: CheckPasses
-    hadolint: CheckPassess
+    hadolint: CheckPasses
 
 @strawberry.type
 class Accessibility:

--- a/docs/scanners.md
+++ b/docs/scanners.md
@@ -115,7 +115,48 @@ For preventative protection, consider using 'gitleaks protect' [pre-commit]((htt
 
 ### Hadolint `Dockerfile`
 
-[`hadolint`](https://github.com/hadolint/hadolint) performs a series of lint checks on each `Dockerfile` found in the repository.
+[`Hadolint`](https://github.com/hadolint/hadolint) is a linter for Dockerfiles. This scanner analyzes the Dockerfiles in the source code repository, and flags any best practices rules that have been broken. 
+
+**Remediation**
+
+Follow the guidelines outlined in results message to update the Dockerfiles.  If your team has decided to not follow a particular rule in certain cases, you can clear the warning in this scanner by including an [inline ignore tag](https://github.com/hadolint/hadolint#inline-ignores) at the Dockerfile location where you would like to by-passed the rule check.  
+
+
+**Data Example**
+```jsonc
+{
+    // ...
+   hadolint: {
+      checkPasses: false
+      metadata: [
+        {
+          Dockerfile: "ui/Dockerfile",
+          RulesViolated: [
+            {
+                code: "DL1000",
+                level: "error",
+                line: 41,
+                message: "unexpected '#'\nexpecting a new line followed by the next instruction"
+            }
+          ]
+        },
+        {
+          Dockerfile: "scanners/web-endpoint-checks/Dockerfile",
+          RulesViolated: [
+            {
+                code: "DL3008",
+                level: "warning",
+                line: 11,
+                message: "Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`"
+            },
+        // ...
+          ]
+        }
+      ]
+      // ...
+    }
+
+```
 
 > TODO
 

--- a/scanners/github-cloned-repo-checks/Dockerfile
+++ b/scanners/github-cloned-repo-checks/Dockerfile
@@ -14,6 +14,11 @@ RUN curl -LO https://github.com/zricethezav/gitleaks/releases/download/v8.18.0/g
     chmod +x /usr/local/bin/gitleaks && \
     rm gitleaks_8.18.0_linux_x64.tar.gz
 
+# Install hadolint
+RUN wget https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64 && \
+    mv hadolint-Linux-x86_64 /usr/local/bin/hadolint && \
+    chmod +x /usr/local/bin/hadolint
+
 COPY package*.json ./
 
 RUN npm ci

--- a/scanners/github-cloned-repo-checks/index.js
+++ b/scanners/github-cloned-repo-checks/index.js
@@ -55,10 +55,10 @@ process.on('SIGINT', () => process.exit(0))
             const results = await check.doRepoCheck()
 
             // console.log('Scan Results:',results)
-            console.log('gitleaks metadata',results.gitleaks.metadata)
-            console.log('gitleaks stingified metadata',JSON.stringify(results.gitleaks.metadata).replace(/"([^"]+)":/g, '$1:'))
-            console.log('hadolint metadata',results.hadolint.metadata)
-            console.log('hadolint stingified metadata',JSON.stringify(results.hadolint.metadata).replace(/"([^"]+)":/g, '$1:').replace(/\/+/g, '_'))
+            // console.log('gitleaks metadata',results.gitleaks.metadata)
+            // console.log('gitleaks stingified metadata',JSON.stringify(results.gitleaks.metadata, null, 4).replace(/"([^"]+)":/g, '$1:'))
+            // console.log('hadolint metadata',results.hadolint.metadata)
+            // console.log('hadolint stingified metadata',JSON.stringify(results.hadolint.metadata, null, 4).replace(/"([^"]+)":/g, '$1:'))
 
             // Mutation to add a graph for the new endpoints
             // TODO: refactor this into a testable query builder function
@@ -83,9 +83,10 @@ process.on('SIGINT', () => process.exit(0))
                             metadata: ${JSON.stringify(results.gitleaks.metadata, null, 4).replace(/"([^"]+)":/g, '$1:')}
                         },
                         hadolint: {
-                            checkPasses: ${results.hadolint.checkPasses},
-                            metadata: ${JSON.stringify(results.hadolint.metadata, null, 4).replace(/"([^"]+)":/g, '$1:').replace(/\/+/g, '_')}
+                            checkPasses: ${results.hadolint.checkPasses}
+                            metadata: ${JSON.stringify(results.hadolint.metadata, null, 4).replace(/"([^"]+)":/g, '$1:')}
                         }
+
 
   
                     }
@@ -110,6 +111,11 @@ process.on('SIGINT', () => process.exit(0))
 await nc.closed();
 
 // nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/ruok-service-autochecker\"}"
+
+// hadolint: {
+//     checkPasses: ${results.hadolint.checkPasses},
+//     metadata: ${JSON.stringify(results.hadolint.metadata, null, 4).replace(/"([^"]+)":/g, '$1:')}
+// }
 
 // hadolint: {
 //     checkPasses: ${results.hadolint.checkPasses},

--- a/scanners/github-cloned-repo-checks/index.js
+++ b/scanners/github-cloned-repo-checks/index.js
@@ -54,9 +54,11 @@ process.on('SIGINT', () => process.exit(0))
             const check = await initializeChecker(checkName, repoName, repoPath)
             const results = await check.doRepoCheck()
 
-            console.log('Scan Results:',results)
+            // console.log('Scan Results:',results)
             console.log('gitleaks metadata',results.gitleaks.metadata)
-            console.log('gitleaks stingified metadata',JSON.stringify(results.gitleaks.metadata))
+            console.log('gitleaks stingified metadata',JSON.stringify(results.gitleaks.metadata).replace(/"([^"]+)":/g, '$1:'))
+            console.log('hadolint metadata',results.hadolint.metadata)
+            console.log('hadolint stingified metadata',JSON.stringify(results.hadolint.metadata).replace(/"([^"]+)":/g, '$1:').replace(/\/+/g, '_'))
 
             // Mutation to add a graph for the new endpoints
             // TODO: refactor this into a testable query builder function
@@ -79,7 +81,13 @@ process.on('SIGINT', () => process.exit(0))
                         gitleaks: {
                             checkPasses: ${JSON.stringify(results.gitleaks.checkPasses, null, 4).replace(/"([^"]+)":/g, '$1:')}
                             metadata: ${JSON.stringify(results.gitleaks.metadata, null, 4).replace(/"([^"]+)":/g, '$1:')}
+                        },
+                        hadolint: {
+                            checkPasses: ${results.hadolint.checkPasses},
+                            metadata: ${JSON.stringify(results.hadolint.metadata, null, 4).replace(/"([^"]+)":/g, '$1:').replace(/\/+/g, '_')}
                         }
+
+  
                     }
                 )
             }
@@ -102,3 +110,13 @@ process.on('SIGINT', () => process.exit(0))
 await nc.closed();
 
 // nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/ruok-service-autochecker\"}"
+
+// hadolint: {
+//     checkPasses: ${results.hadolint.checkPasses},
+//     metadata: ${JSON.stringify(results.hadolint.metadata, null, 4).replace(/"([^"]+)":/g, '$1:').replace(/\n/g, '')}
+// }
+
+                        // hadolint: {
+                        //     checkPasses: ${results.hadolint.checkPasses},
+                        //     metadata: ${JSON.stringify(results.hadolint.metadata, null, 4).replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')   
+                        // }

--- a/scanners/github-cloned-repo-checks/index.js
+++ b/scanners/github-cloned-repo-checks/index.js
@@ -46,7 +46,7 @@ process.on('SIGINT', () => process.exit(0))
 
             // Clone repository
             const repoPath = await cloneRepository(gitHubEventPayload.endpoint, repoName)
-            console.log ('repoPath', repoPath)
+            console.log ('repoPath', repoPath, '\n')
 
             // Instantiate and do the check(s)
             const checkName = 'allChecks'
@@ -95,8 +95,8 @@ process.on('SIGINT', () => process.exit(0))
 
                 console.log('Scan results saved to database.')
 
-            } catch {
-                console.log("Error occured - unable to save to database. \n", error.message)
+            } catch (error) {
+                console.error("An error occurred - unable to save to the database.", error);
             }
             
             // Remove temp repository

--- a/scanners/github-cloned-repo-checks/package-lock.json
+++ b/scanners/github-cloned-repo-checks/package-lock.json
@@ -12,6 +12,7 @@
                 "arangojs": "^8.5.0",
                 "dotenv-safe": "^8.2.0",
                 "fs-extra": "^11.1.1",
+                "glob": "^10.3.10",
                 "graphql-request": "^6.1.0",
                 "jest": "^29.7.0",
                 "js-yaml": "^4.1.0",
@@ -610,6 +611,95 @@
                 "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
             }
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+            "dependencies": {
+                "string-width": "^5.1.2",
+                "string-width-cjs": "npm:string-width@^4.2.0",
+                "strip-ansi": "^7.0.1",
+                "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+                "wrap-ansi": "^8.1.0",
+                "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+            "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+            "version": "9.2.2",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        },
+        "node_modules/@isaacs/cliui/node_modules/string-width": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+            "dependencies": {
+                "eastasianwidth": "^0.2.0",
+                "emoji-regex": "^9.2.2",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+            "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+            "dependencies": {
+                "ansi-regex": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+            }
+        },
+        "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+            "dependencies": {
+                "ansi-styles": "^6.1.0",
+                "string-width": "^5.0.1",
+                "strip-ansi": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -824,6 +914,25 @@
                 }
             }
         },
+        "node_modules/@jest/reporters/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -972,6 +1081,15 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
             "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
+        },
+        "node_modules/@pkgjs/parseargs": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+            "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+            "optional": true,
+            "engines": {
+                "node": ">=14"
+            }
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.27.8",
@@ -1574,6 +1692,11 @@
                 "dotenv": "^8.2.0"
             }
         },
+        "node_modules/eastasianwidth": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.4.554",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.554.tgz",
@@ -1728,6 +1851,32 @@
                 "node": ">=8"
             }
         },
+        "node_modules/foreground-child": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+            "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+            "dependencies": {
+                "cross-spawn": "^7.0.0",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/foreground-child/node_modules/signal-exit": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/fs-extra": {
             "version": "11.1.1",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
@@ -1795,19 +1944,43 @@
             }
         },
         "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "version": "10.3.10",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+            "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^2.3.5",
+                "minimatch": "^9.0.1",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+                "path-scurry": "^1.10.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
             },
             "engines": {
-                "node": "*"
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/glob/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/glob/node_modules/minimatch": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -2096,6 +2269,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/jackspeak": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+            "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+            "dependencies": {
+                "@isaacs/cliui": "^8.0.2"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            },
+            "optionalDependencies": {
+                "@pkgjs/parseargs": "^0.11.0"
+            }
+        },
         "node_modules/jest": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
@@ -2238,6 +2428,25 @@
                 "ts-node": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/jest-config/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/jest-diff": {
@@ -2502,6 +2711,25 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+            }
+        },
+        "node_modules/jest-runtime/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/jest-snapshot": {
@@ -2874,6 +3102,14 @@
                 "node": "*"
             }
         },
+        "node_modules/minipass": {
+            "version": "7.0.4",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+            "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -3098,6 +3334,29 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+        },
+        "node_modules/path-scurry": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+            "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+            "dependencies": {
+                "lru-cache": "^9.1.1 || ^10.0.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+            "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+            "engines": {
+                "node": "14 || >=16.14"
+            }
         },
         "node_modules/peek-readable": {
             "version": "4.1.0",
@@ -3433,7 +3692,33 @@
                 "node": ">=8"
             }
         },
+        "node_modules/string-width-cjs": {
+            "name": "string-width",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi-cjs": {
+            "name": "strip-ansi",
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -3520,6 +3805,25 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/test-exclude/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/tmpl": {
@@ -3688,6 +3992,23 @@
             }
         },
         "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi-cjs": {
+            "name": "wrap-ansi",
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",

--- a/scanners/github-cloned-repo-checks/package.json
+++ b/scanners/github-cloned-repo-checks/package.json
@@ -14,6 +14,7 @@
         "arangojs": "^8.5.0",
         "dotenv-safe": "^8.2.0",
         "fs-extra": "^11.1.1",
+        "glob": "^10.3.10",
         "graphql-request": "^6.1.0",
         "jest": "^29.7.0",
         "js-yaml": "^4.1.0",

--- a/scanners/github-cloned-repo-checks/src/all-checks.js
+++ b/scanners/github-cloned-repo-checks/src/all-checks.js
@@ -5,6 +5,7 @@ import { HasSecurityMd } from "./has-security-md.js"
 import { DotDockerIgnoreDetails, DotGitIgnoreDetails }  from "./get-dotignore-details.js"
 import { CheckOnClonedRepoInterface } from './check-on-cloned-repo-interface.js'
 import { Gitleaks } from './gitleaks.js'
+import { Hadolint } from './hadolint.js'
 
 
 export class AllChecks extends CheckOnClonedRepoInterface {
@@ -19,7 +20,8 @@ export class AllChecks extends CheckOnClonedRepoInterface {
         new HasSecurityMd(repoName, clonedRepoPath),
         new DotDockerIgnoreDetails(repoName, clonedRepoPath),
         new DotGitIgnoreDetails(repoName, clonedRepoPath),
-        new Gitleaks(repoName, clonedRepoPath)
+        new Gitleaks(repoName, clonedRepoPath),
+        new Hadolint(repoName, clonedRepoPath)
       ];
     }
   
@@ -38,7 +40,8 @@ export class AllChecks extends CheckOnClonedRepoInterface {
         hasSecurityMd: checkResults[3],
         dotDockerIgnoreDetails: checkResults[4],
         dotGitIgnoreDetails: checkResults[5],
-        gitleaks: checkResults[6]
+        gitleaks: checkResults[6],
+        hadolint: checkResults[7]
       }
   
       return allResults;

--- a/scanners/github-cloned-repo-checks/src/gitleaks.js
+++ b/scanners/github-cloned-repo-checks/src/gitleaks.js
@@ -153,10 +153,10 @@ export class Gitleaks extends CheckOnClonedRepoInterface {
           checkPasses = true
         }
 
-        console.log({
-          checkPasses: checkPasses,
-          metadata: gitleaksResult
-        })
+        // console.log({
+        //   checkPasses: checkPasses,
+        //   metadata: gitleaksResult
+        // })
 
         return {
           checkPasses: checkPasses,

--- a/scanners/github-cloned-repo-checks/src/gitleaks.js
+++ b/scanners/github-cloned-repo-checks/src/gitleaks.js
@@ -114,23 +114,18 @@ async function runGitleaks(clonedRepoPath) {
         errorMessage: 'An error was encountered running the Gitleaks check.',
       };
     }
-    // console.log('gitleaks results:', results)
 
     return results
+
   } catch (error) {
     console.error(error.message);
-    // Handle the error as needed
     return {
-      exitCode: -1, // Or another appropriate error code
+      exitCode: -1, 
       leaksFound: null,
       errorMessage: 'An unexpected error occurred.',
     };
   }
 }
-
-// const clonedRepoPath = '/tmp/ruok-service-autochecker-1700060804550'
-// const results = await runGitleaks(clonedRepoPath) 
-// console.log(JSON.stringify(results, null, 2))
 
 
 export class Gitleaks extends CheckOnClonedRepoInterface {
@@ -152,11 +147,6 @@ export class Gitleaks extends CheckOnClonedRepoInterface {
         } else {
           checkPasses = true
         }
-
-        // console.log({
-        //   checkPasses: checkPasses,
-        //   metadata: gitleaksResult
-        // })
 
         return {
           checkPasses: checkPasses,

--- a/scanners/github-cloned-repo-checks/src/gitleaks.js
+++ b/scanners/github-cloned-repo-checks/src/gitleaks.js
@@ -114,7 +114,7 @@ async function runGitleaks(clonedRepoPath) {
         errorMessage: 'An error was encountered running the Gitleaks check.',
       };
     }
-    console.log('gitleaks results:', results)
+    // console.log('gitleaks results:', results)
 
     return results
   } catch (error) {

--- a/scanners/github-cloned-repo-checks/src/hadolint.js
+++ b/scanners/github-cloned-repo-checks/src/hadolint.js
@@ -10,7 +10,8 @@ import { glob } from 'glob'
 import { CheckOnClonedRepoInterface } from './check-on-cloned-repo-interface.js'
 
 
-async function runHadolint(dockerfilePath) {
+async function runHadolintOnDockerfile(dockerfilePath) {
+  // lints a particular Dockerfile
     try {
         const hadolintProcess = spawn('hadolint', [dockerfilePath, '--no-fail', '--format', 'json'])
 
@@ -44,13 +45,19 @@ async function runHadolint(dockerfilePath) {
 }
 
 async function hadolintRepo(clonedRepoPath) {
+  // For each Dockerfile in Repo, runs hadolint and consolidates results 
     const dockerfilePaths = glob.sync(path.join(clonedRepoPath, '**', '*Dockerfile*'));
-    let results = {};
+    // let results = {};
+    let results = [];
   
     for (const dockerfilePath of dockerfilePaths) {
       const relativePath = path.relative(clonedRepoPath, dockerfilePath);
-      const hadolintResult = await runHadolint(dockerfilePath);
-      results[relativePath] = hadolintResult;
+      const hadolintResult = await runHadolintOnDockerfile(dockerfilePath);
+      // results[relativePath] = hadolintResult;
+      results.push({
+        Dockerfile: relativePath,
+        RulesViolated: hadolintResult,
+    });
     }
 
     return results;

--- a/scanners/github-cloned-repo-checks/src/hadolint.js
+++ b/scanners/github-cloned-repo-checks/src/hadolint.js
@@ -1,0 +1,115 @@
+// https://thenewstack.io/hadolint-lint-dockerfiles-from-the-command-line/#:~:text=is%20called%20Hadolint.-,Hadolint%20is%20a%20command%20line%20tool%20that%20helps%20you%20ensure,tool)%20to%20lint%20the%20code.
+
+// Hadolint looks for built in rules https://github.com/hadolint/hadolint#rules
+// And suggests best practices https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+
+import { spawn } from 'child_process';
+import { once } from 'events';
+import path from 'path';
+import { glob } from 'glob'
+import { CheckOnClonedRepoInterface } from './check-on-cloned-repo-interface.js'
+
+
+async function runHadolint(dockerfilePath) {
+    try {
+        const hadolintProcess = spawn('hadolint', [dockerfilePath, '--no-fail', '--format', 'json'])
+
+        let stdoutData = '';
+        let stderrData = '';
+    
+        hadolintProcess.stdout.on('data', (data) => {
+            stdoutData += data.toString();
+          });
+    
+        hadolintProcess.stderr.on('data', (data) => {
+          stderrData += data.toString();
+          console.log('stderrData', stderrData)
+        });
+
+        const [code] = await once(hadolintProcess, 'close');
+
+        // Get details from the report output as JSON, then filter out extra fields
+        const hadolintJson = JSON.parse(stdoutData);
+        const filteredResults = hadolintJson.map(({ code, level, line, message }) => ({
+            code,
+            level,
+            line,
+            message,
+          }));
+        return(filteredResults)
+
+      } catch (error) {
+        console.error(error.message);
+    }
+}
+
+async function hadolintRepo(clonedRepoPath) {
+    const dockerfilePaths = glob.sync(path.join(clonedRepoPath, '**', '*Dockerfile*'));
+    let results = {};
+  
+    for (const dockerfilePath of dockerfilePaths) {
+      const relativePath = path.relative(clonedRepoPath, dockerfilePath);
+      const hadolintResult = await runHadolint(dockerfilePath);
+      results[relativePath] = hadolintResult;
+    }
+
+    return results;
+}
+
+function areAllArraysEmpty(obj) {
+  for (const key in obj) {
+    if (obj[key] instanceof Array && obj[key].length > 0) {
+      return false; // If any array is not empty, return false
+    }
+  }
+  return true; e
+}
+
+// // const clonedRepoPath = '/tmp/ruok-service-autochecker-1701808283929'
+// // const clonedRepoPath ='../../test-repo/ruok-service-autochecker'
+// const clonedRepoPath = '../../test-repo/django-htmx-autocomplete'
+// const results = await hadolintRepo(clonedRepoPath)
+// console.log(results)
+
+// const ifempty = areAllArraysEmpty(results)
+// console.log(ifempty)
+
+// const isEmpty = isObjectEmpty(results);
+
+// console.log('Is the object empty?', isEmpty);
+// // (isObjectEmpty(hadolintResult)
+
+
+export class Hadolint extends CheckOnClonedRepoInterface {
+    constructor(repoName, clonedRepoPath) {
+        super(repoName, clonedRepoPath);
+        this.clonedRepoPath = clonedRepoPath;
+        this.repoName = repoName;
+    }
+
+    async doRepoCheck() {
+        try {
+            const hadolintResult = await hadolintRepo(this.clonedRepoPath);
+            let areResults = areAllArraysEmpty(hadolintResult) // Will result in true if no dockerfiles and if no warnings or errors from linting. 
+
+            if (Object.keys(hadolintResult).length === 0){ // In the case of no Dockerfiles in repo
+              areResults = null
+            }
+      
+            return {
+              checkPasses: areResults,
+              metadata: hadolintResult
+            }
+
+        } catch (error) {
+            console.error(error.message);
+            // Handle the error as needed
+            return {
+                checkPasses: null,
+                metadata: {
+                errorMessage: 'An unexpected error occurred.',
+                },
+            };
+        }
+    }
+}

--- a/scanners/github-cloned-repo-checks/src/hadolint.js
+++ b/scanners/github-cloned-repo-checks/src/hadolint.js
@@ -48,7 +48,7 @@ async function hadolintRepo(clonedRepoPath) {
   // For each Dockerfile in Repo, runs hadolint and consolidates results 
     const dockerfilePaths = glob.sync(path.join(clonedRepoPath, '**', '*Dockerfile*'));
     // let results = {};
-    let results = [];
+    let results = []; 
   
     for (const dockerfilePath of dockerfilePaths) {
       const relativePath = path.relative(clonedRepoPath, dockerfilePath);
@@ -63,6 +63,7 @@ async function hadolintRepo(clonedRepoPath) {
     return results;
 }
 
+
 function areAllArraysEmpty(obj) {
   for (const key in obj) {
     if (obj[key] instanceof Array && obj[key].length > 0) {
@@ -71,20 +72,6 @@ function areAllArraysEmpty(obj) {
   }
   return true; e
 }
-
-// // const clonedRepoPath = '/tmp/ruok-service-autochecker-1701808283929'
-// // const clonedRepoPath ='../../test-repo/ruok-service-autochecker'
-// const clonedRepoPath = '../../test-repo/django-htmx-autocomplete'
-// const results = await hadolintRepo(clonedRepoPath)
-// console.log(results)
-
-// const ifempty = areAllArraysEmpty(results)
-// console.log(ifempty)
-
-// const isEmpty = isObjectEmpty(results);
-
-// console.log('Is the object empty?', isEmpty);
-// // (isObjectEmpty(hadolintResult)
 
 
 export class Hadolint extends CheckOnClonedRepoInterface {
@@ -110,11 +97,10 @@ export class Hadolint extends CheckOnClonedRepoInterface {
 
         } catch (error) {
             console.error(error.message);
-            // Handle the error as needed
             return {
                 checkPasses: null,
                 metadata: {
-                errorMessage: 'An unexpected error occurred.',
+                errorMessage: 'An unexpected error occurred with hadolint check.',
                 },
             };
         }

--- a/scanners/github-cloned-repo-checks/src/hadolint.js
+++ b/scanners/github-cloned-repo-checks/src/hadolint.js
@@ -24,7 +24,7 @@ async function runHadolintOnDockerfile(dockerfilePath) {
     
         hadolintProcess.stderr.on('data', (data) => {
           stderrData += data.toString();
-          console.log('stderrData', stderrData)
+          // console.log('stderrData', stderrData)
         });
 
         const [code] = await once(hadolintProcess, 'close');
@@ -64,13 +64,14 @@ async function hadolintRepo(clonedRepoPath) {
 }
 
 
-function areAllArraysEmpty(obj) {
-  for (const key in obj) {
-    if (obj[key] instanceof Array && obj[key].length > 0) {
-      return false; // If any array is not empty, return false
+function anyArrayNonEmpty(obj) {
+  // If no rules violated for hadolint scan, ruleViolated will be empty
+  for (const entry of obj) {
+    if (entry.RulesViolated && entry.RulesViolated.length > 0) {
+      return true; // If any RulesViolated array is non-empty, return true
     }
   }
-  return true; e
+  return false; // Return false only if all RulesViolated arrays are empty
 }
 
 
@@ -84,7 +85,7 @@ export class Hadolint extends CheckOnClonedRepoInterface {
     async doRepoCheck() {
         try {
             const hadolintResult = await hadolintRepo(this.clonedRepoPath);
-            let areResults = areAllArraysEmpty(hadolintResult) // Will result in true if no dockerfiles and if no warnings or errors from linting. 
+            let areResults = !anyArrayNonEmpty(hadolintResult) // areResults will result in true if no dockerfiles and if no warnings or errors from linting.
 
             if (Object.keys(hadolintResult).length === 0){ // In the case of no Dockerfiles in repo
               areResults = null


### PR DESCRIPTION
Closes https://github.com/PHACDataHub/ruok-service-autochecker/issues/79
Adds hadolint functionality to the github-cloned-repo scanner to lint all Dockerfiles within a repository.

If hadolint rules of any level are broken, checkPasses fails, which can be remediated with a fix or ignore.  

Had some issues breaking bug issues in PR #78 (Feat hadolint), so restarted from main, and pulled changes over.  Needed to restructure the results to push the  dockerfile path names down a level, and not be the results key as the '/'s were causing issues with graphql/ arangodb.  Can restructure/ rename in the future. 

 - [x] Install hadolint in the github-cloned-repo Dockerfile
  - [x] update the graphQL api query and inputTypes
  - [x] Update docs to include description and remediation
  - [x] change to use glob and pick up any file with Dockerfile within filename
  - [x] Add to docs 