### PR TITLE
fix-endpoint-scanner-to-work-with-graph-updater

### DIFF
--- a/scanners/web-endpoint/.env.example
+++ b/scanners/web-endpoint/.env.example
@@ -1,2 +1,11 @@
+# NATS_URL=localhost:4222
+# GRAPHQL_URL=http://127.0.0.1:4000/graphql
+
 NATS_URL=localhost:4222
-GRAPHQL_URL=http://127.0.0.1:4000/graphql
+# NATS_URL=nats:4222
+GRAPHQL_URL=http://localhost:4000/graphql
+# GRAPHQL_URL=http://graphql-api:4000/graphql
+
+# NATS sub stream
+# NATS_SUB_STREAM="EventsScanner.githubEndpoints"
+NATS_SUB_STREAM=EventsScanner.githubEndpoints

--- a/scanners/web-endpoint/.env.example
+++ b/scanners/web-endpoint/.env.example
@@ -1,11 +1,3 @@
-# NATS_URL=localhost:4222
-# GRAPHQL_URL=http://127.0.0.1:4000/graphql
-
-NATS_URL=localhost:4222
-# NATS_URL=nats:4222
-GRAPHQL_URL=http://localhost:4000/graphql
-# GRAPHQL_URL=http://graphql-api:4000/graphql
-
-# NATS sub stream
-# NATS_SUB_STREAM="EventsScanner.githubEndpoints"
-NATS_SUB_STREAM=EventsScanner.githubEndpoints
+NATS_URL=O.0.0.0:4222
+GRAPHQL_URL=0.0.0.0:4000/graphql
+NATS_SUB_STREAM=EventsScanner.webEndpoints

--- a/scanners/web-endpoint/README.md
+++ b/scanners/web-endpoint/README.md
@@ -1,16 +1,16 @@
+# Puppeteer Web Accessibility Checks 
+
 Accessibiltiy checks - information found here - https://www.w3.org/TR/wai-aria/
-Using axe-puppeteer - launches in chrome (headless/ doesn't actually pop-up) to perform checks 
 
 nats cli command:
 ```
-nats pub 'WebEvent' '{"productName": "Observatory", "webEndpoints": ["https://safeinputs.phac.alpha.canada.ca", "https://hopic-sdpac.phac-aspc.alpha.canada.ca", "https://hopic-sdpac.k8s.phac-aspc.alpha.canada.ca", "https://safeinputs.phac.alpha.canada.ca/graphql", "https://api.example.com/api/fakeEndpoint"], "domains": ["entreessecurisees.aspc.alpha.canada.ca", "safeinputs.phac-aspc.alpha.canada.ca", "safeinputs.phac.alpha.canada.ca"], "containerEndpoints": "northamerica-northeast1-docker.pkg.dev/phx-01h1yptgmche7jcy01wzzpw2rf/hello-world-app"}'
+nats pub "EventsScanner.webEndpoints" "{\"endpoint\":\"https://safeinputs.phac.alpha.canada.ca\"}"
 ```
+
 
 
 TODO
 * save to database with API
-* modify index.js to only process one url, and use url rather than webEndpoints
-* docs / docstrings - add to doc pages 
 * have this actually crawl instead of finding/ scanning only the surface slugs 
 * address credentials by creating service account/ prinicipal to single sign on with minimal permissions to scan set pages for accessibility
 

--- a/scanners/web-endpoint/index.js
+++ b/scanners/web-endpoint/index.js
@@ -13,7 +13,6 @@ const {
 } = process.env;
 
 
-
 // NATs connection 
 const nc = await connect({ servers: NATS_URL, })
 const jc = JSONCodec()
@@ -96,3 +95,5 @@ process.on('SIGINT', () => process.exit(0))
 
 
 await nc.closed();
+
+// nats pub "EventsScanner.webEndpoints" "{\"endpoint\":\"https://safeinputs.phac.alpha.canada.ca\"}"


### PR DESCRIPTION
Updated scanner to receive payload from graph updater.  

Update - turns out it was just missing the NATS_PUB_STREAM.  Updated the nats url and api url to work locally and with k8s.