### PR TITLE
Some Refactoring

### DIFF
--- a/api/src/model.py
+++ b/api/src/model.py
@@ -31,7 +31,26 @@ class GraphDB:
         return True
 
     def _key_safe_url(self, url: str) -> str:
-        return url.replace("://", "-").replace("/", "-").replace("{","(").replace("}",")")
+        url = url.replace("://", "-") \
+                .replace("/", "-") \
+                .replace("{", "(") \
+                .replace("}", ")") \
+                .replace("?", "-") \
+                .replace("&", "-") \
+                .replace("#", "-") \
+                .replace("[", "(") \
+                .replace("]", ")") \
+                .replace("\\", "-") \
+                .replace("%", "-") \
+                .replace('"', "'") \
+                .replace("<", "(") \
+                .replace(">", ")")
+
+        allowed_chars = set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-.@()+,=;$!*'%:")
+        
+        safe_url = ''.join(c if c in allowed_chars else '-' for c in url)
+        
+        return safe_url
 
     def insert_endpoint(self, endpoint):
         endpoint_dict = strawberry.asdict(endpoint)

--- a/graph-updater/index.js
+++ b/graph-updater/index.js
@@ -1,220 +1,245 @@
-import { connect, JSONCodec } from 'nats'
+import { connect, JSONCodec } from 'nats';
 
 import { GraphQLClient, gql } from 'graphql-request';
 
-import { getEndpoint, getEndpointKind } from "./src/endpoint.js";
+import { getEndpoint, getEndpointKind } from './src/endpoint.js';
 
 import { publishToNats } from './src/utils.js';
 
-import 'dotenv-safe/config.js'
+import 'dotenv-safe/config.js';
 
-const {
-  NATS_URL,
-  GRAPHQL_URL,
-} = process.env;
+const { NATS_URL, GRAPHQL_URL } = process.env;
 
-const NATS_SUB_STREAM = "EventsUpdate" // Note - for checks that need branch, the substream will be different (right now blanketing with 'main')
+const NATS_SUB_STREAM = 'EventsUpdate'; // Note - for checks that need branch, the substream will be different (right now blanketing with 'main')
 
-const CONTAINER_ENDPOINT_QUEUE = "EventsScanner.containerEndpoints"
-const WEB_ENDPOINT_QUEUE = "EventsScanner.webEndpoints"
-const GITHUB_ENDPOINT_QUEUE = "EventsScanner.githubEndpoints"
+const CONTAINER_ENDPOINT_QUEUE = 'EventsScanner.containerEndpoints';
+const WEB_ENDPOINT_QUEUE = 'EventsScanner.webEndpoints';
+const GITHUB_ENDPOINT_QUEUE = 'EventsScanner.githubEndpoints';
 
-
-// NATs connection 
-const nc = await connect({ servers: NATS_URL, })
+// NATs connection
+const nc = await connect({ servers: NATS_URL });
 const jc = JSONCodec();
 
-const sub = nc.subscribe(NATS_SUB_STREAM)
-console.log('🚀 Connected to NATS server - listening on ...', sub.subject, "channel...");
+const sub = nc.subscribe(NATS_SUB_STREAM);
+console.log(
+  '🚀 Connected to NATS server - listening on ...',
+  sub.subject,
+  'channel...',
+);
 
-process.on('SIGTERM', () => process.exit(0))
-process.on('SIGINT', () => process.exit(0))
-  ; (async () => {
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));
+(async () => {
+  for await (const message of sub) {
+    try {
+      let endpointEventPayload = await jc.decode(message.data);
 
-    for await (const message of sub) {
-        try{
-          let endpointEventPayload = await jc.decode(message.data)
+      console.log(
+        `\n****************************** ${new Date()} ********************************`,
+      );
+      console.log(
+        `Recieved from ... ${message.subject}:\n ${JSON.stringify(endpointEventPayload)}`,
+      );
 
-          console.log(`\n****************************** ${new Date()} ********************************`)
-          console.log(`Recieved from ... ${message.subject}:\n ${JSON.stringify(endpointEventPayload)}`)
-    
-          let githubEndpoints = new Set(), webEndpoints = new Set(), containerEndpoints = new Set();
-    
-          if(endpointEventPayload.endpoint.payloadType && 
-              endpointEventPayload.endpoint.payloadType == 'service'){
-            // Insert this Service and it's WebURL(s) & Repository URL(s) into the graphDB.
-            // Also build a graph with the Service as root and the URLs as its children.
-            let payload = endpointEventPayload.endpoint;
-    
-            const product = `{url : "${payload.serviceName}", kind : "Service"}`
-    
-            payload.webEndpoint = (payload.webEndpoint).includes("https") ? payload.webEndpoint : "https://" + payload.webEndpoint
-            const l = payload.webEndpoint.length;
-            payload.webEndpoint = payload.webEndpoint.substring(0, l-1)
-            console.log(payload.webEndpoint)
-    
-            let urls = [];
-    
-            urls.push(`{url : "${payload.repoEndpoint}", kind : "Github"}`);
-    
-            urls.push(`{url : "${payload.webEndpoint}", kind : "Web"}`);
-    
-            urls = `[${Array.from(urls).join(',')}]`
-    
-            const mutation = gql`
+      let githubEndpoints = new Set(),
+        webEndpoints = new Set(),
+        containerEndpoints = new Set();
+
+      if (
+        endpointEventPayload.endpoint.payloadType &&
+        endpointEventPayload.endpoint.payloadType == 'service'
+      ) {
+        // Insert this Service and it's WebURL(s) & Repository URL(s) into the graphDB.
+        // Also build a graph with the Service as root and the URLs as its children.
+        let payload = endpointEventPayload.endpoint;
+
+        const product = `{url : "${payload.serviceName}", kind : "Service"}`;
+
+        payload.webEndpoint = payload.webEndpoint.includes('https')
+          ? payload.webEndpoint
+          : 'https://' + payload.webEndpoint;
+        const l = payload.webEndpoint.length;
+        payload.webEndpoint = payload.webEndpoint.substring(0, l - 1);
+        console.log(payload.webEndpoint);
+
+        let urls = [];
+
+        urls.push(`{url : "${payload.repoEndpoint}", kind : "Github"}`);
+
+        urls.push(`{url : "${payload.webEndpoint}", kind : "Web"}`);
+
+        urls = `[${Array.from(urls).join(',')}]`;
+
+        const mutation = gql`
             mutation {
                 product(product : ${product},
                         urls : ${urls})
             }
-            `
-    
-            // New GraphQL client - TODO: remove hard-coded URL
-            const graphqlClient = new GraphQLClient(GRAPHQL_URL);
-            // Write mutation to GraphQL API
-            const mutationResponse = await graphqlClient.request(mutation);
-            console.log(mutationResponse);
-            
-            // Change the original endpointEventPayload to conform with the code 
-            // that follows this if block. Also append the web URL for the service
-            // to the webEndpoints list, such that it can be scanned.
-            endpointEventPayload.endpoint = payload.repoEndpoint;
-    
-            // Append the web URL for the service
-            // to the webEndpoints list, such that it can be scanned.
-            webEndpoints.add(payload.webEndpoint);
+            `;
+
+        // New GraphQL client - TODO: remove hard-coded URL
+        const graphqlClient = new GraphQLClient(GRAPHQL_URL);
+        // Write mutation to GraphQL API
+        const mutationResponse = await graphqlClient.request(mutation);
+        console.log(mutationResponse);
+
+        // Change the original endpointEventPayload to conform with the code
+        // that follows this if block. Also append the web URL for the service
+        // to the webEndpoints list, such that it can be scanned.
+        endpointEventPayload.endpoint = payload.repoEndpoint;
+        githubEndpoints.add(payload.repoEndpoint);
+
+        // Append the web URL for the service
+        // to the webEndpoints list, such that it can be scanned.
+        webEndpoints.add(payload.webEndpoint);
+      }
+
+      // Every endpoint handler knows how to get its own graph metadata
+      // from its endpoint.
+      if (endpointEventPayload.endpoint !== 'None') {
+        const endpointKind = getEndpointKind(endpointEventPayload.endpoint)[0];
+        // Each kind of endpoint knows how to get its own metadata (i.e. what endpoints are
+        // related to this endpoint?); polymorphic method getGraphMetadata knows how to
+        // parse the endpointEventPayload object to extract metadata about related endpoints.
+
+        // If the kind is github then add the git repo URL to the set for scanning
+        console.log(`NIR LOGS: ${endpointKind}`);
+        if (endpointKind == 'github') {
+          githubEndpoints.add(endpointEventPayload.endpoint);
+        }
+
+        const endpointHandler = getEndpoint(endpointKind);
+        let newEndpointsWithKind =
+          await endpointHandler.getGraphMetaData(endpointEventPayload);
+
+        newEndpointsWithKind = Array.from(newEndpointsWithKind);
+
+        //Extract only URLS
+        const newEndpoints = Array.from(newEndpointsWithKind).map(
+          (endpoint, idx) => (endpoint.url),
+        );
+
+        //Stringify each entry in newEndpointsWithKind
+        // newEndpointsWithKind = newEndpointsWithKind.map((endpoint) => {
+        //   return `{url : "${endpoint.url}", kind : "${endpoint.kind}"}`;
+        // });
+
+        // // Create string serialized array of endpoints associated with this endpoint
+        const newEndpointsString = `["${Array.from(newEndpoints).join('", "')}"]`;
+        // const newEndpointsWithKindString = `[${Array.from(newEndpointsWithKind).join(',')}]`;
+
+        // Mutation to add a graph for the new endpoints
+        const mutation = gql`
+          mutation UpdateEndPoints($urls: [EndpointInput!]!) {
+            endpoints(urls: $urls)
           }
-    
-          // Every endpoint handler knows how to get its own graph metadata
-          // from its endpoint.
-          if(endpointEventPayload.endpoint !== "None"){
-            
+        `;
+        const variables = {
+          urls: newEndpointsWithKind,
+        };
+        console.log(mutation);
+        // New GraphQL client - TODO: remove hard-coded URL
+        const graphqlClient = new GraphQLClient(GRAPHQL_URL);
+        // Write mutation to GraphQL API
+        const mutationResponse = await graphqlClient.request(mutation, variables);
 
-              const endpointKind = getEndpointKind(endpointEventPayload.endpoint)[0];
-              // Each kind of endpoint knows how to get its own metadata (i.e. what endpoints are
-              // related to this endpoint?); polymorphic method getGraphMetadata knows how to
-              // parse the endpointEventPayload object to extract metadata about related endpoints.
+        console.log('graphql mutation complete');
 
-              // If the kind is github then add the git repo URL to the set for scanning
-              if(endpointKind == 'github'){
-                githubEndpoints.add(endpointEventPayload.endpoint);
-              }
-          
-              const endpointHandler = getEndpoint(endpointKind);
-              let newEndpointsWithKind = await endpointHandler.getGraphMetaData(endpointEventPayload);
-              
-              newEndpointsWithKind = Array.from(newEndpointsWithKind);
+        // Now that we've written the new graph to the database, we need to query
+        // the same subgraph since there may be existing nodes in the database
+        // that require a new scan.
 
-              //Extract only URLS
-              const newEndpoints = Array.from(newEndpointsWithKind).map((endpoint,idx)=> {
-                                          return endpoint.url;
-                                      });
-
-              //Stringify each entry in newEndpointsWithKind
-              newEndpointsWithKind = newEndpointsWithKind.map(endpoint => {
-                                      return `{url : "${endpoint.url}", kind : "${endpoint.kind}"}`;
-                                      
-              })
-              
-              // Create string serialized array of endpoints associated with this endpoint
-              const newEndpointsString = `["${Array.from(newEndpoints).join('", "')}"]`;
-              const newEndpointsWithKindString= `[${Array.from(newEndpointsWithKind).join(',')}]`
-        
-              // Mutation to add a graph for the new endpoints
-              const mutation = gql`
-              mutation {
-                endpoints(urls: ${newEndpointsWithKindString}) 
-              }
-              `;
-              
-              console.log(mutation)
-              // New GraphQL client - TODO: remove hard-coded URL
-              const graphqlClient = new GraphQLClient(GRAPHQL_URL);
-              // Write mutation to GraphQL API
-              const mutationResponse = await graphqlClient.request(mutation);
-        
-              console.log('graphql mutation complete')
-        
-              // Now that we've written the new graph to the database, we need to query
-              // the same subgraph since there may be existing nodes in the database
-              // that require a new scan.
-
-              // Based on the current approach, the regex matcher finds matching URLs, OLD or NEW
-              // This removes the need to fire a qurey to find existing URLs, beacuse the scanner is going
-              // to pick up EVERYTHING. If the regex matcher does not pick up on an OLD URL, that means
-              // that URL is no longer in use and should not be scanned
-              const query = gql`
-              query {
-                endpoints(urls: ${newEndpointsString}) {
+        // Based on the current approach, the regex matcher finds matching URLs, OLD or NEW
+        // This removes the need to fire a qurey to find existing URLs, beacuse the scanner is going
+        // to pick up EVERYTHING. If the regex matcher does not pick up on an OLD URL, that means
+        // that URL is no longer in use and should not be scanned
+        const query = gql`
+              query GetEndpoints($urls: [String!]!){
+                endpoints(urls: $urls) {
                   url
                 }
               }
               `;
-        
-              const queryResponse = await graphqlClient.request(query);
 
-              const endpointDispatch = {
-                githubEndpoint: githubEndpoints,
-                webEndpoint: webEndpoints,
-                containerEndpoint: containerEndpoints,
-              }
-              
-              newEndpointsWithKind.forEach(endpoint => {
-                const ep = JSON.parse(endpoint.replace('url','"url"').replace('kind','"kind"'));
-                const kind = ep.kind;
-                if(kind == 'Github'){
-                  endpointDispatch['githubEndpoint'].add(ep.url);
-                }
-                else if(kind == 'Docker'){
-                  endpointDispatch['containerEndpoint'].add(ep.url);
-                }
-                else if(kind == 'Database'){
-                  // TODO
-                }
-                else if(kind == 'EmailService'){
-                  // TODO
-                }
-                else if(kind == 'MessageBroker'){
-                  // TODO
-                }
-                else if(kind == 'CloudStorage'){
-                  // TODO
-                }
-              });
+        const queryVariables = {
+          urls: newEndpoints,
+        };
+        const queryResponse = await graphqlClient.request(query, queryVariables);
 
-              // // TODO :also graph relation updater needs to know how to figure out what kind of
-              // // url each endpoint is (e.g. github endpoint, web endpoint, etc.)
-              // for (let i = 0; i < queryResponse.endpoints.length; i++) {
-              //   //const endpointKinds = getEndpointKind(queryResponse.endpoints[i]["url"]);
-              //   for (let j = 0; j < endpointKinds.length; j++) {
-              //     if(endpointDispatch[endpointKinds[j]]){
-              //       endpointDispatch[endpointKinds[j]].push(queryResponse.endpoints[i]["url"]);
-              //     }
-              //   }
-              // }
+        const endpointDispatch = {
+          githubEndpoint: githubEndpoints,
+          webEndpoint: webEndpoints,
+          containerEndpoint: containerEndpoints,
+        };
 
-              console.log(endpointDispatch);
-        
-              //Queue up new endpoints to be analyzed by the appropriate scanners
-              await publishToNats(nc, jc, CONTAINER_ENDPOINT_QUEUE, Array.from(endpointDispatch["containerEndpoint"]));
-              console.log("published container endpoint events");
-              await publishToNats(nc, jc, WEB_ENDPOINT_QUEUE, Array.from(endpointDispatch["webEndpoint"]));
-              console.log("published web endpoint events");
-              await publishToNats(nc, jc, GITHUB_ENDPOINT_QUEUE, Array.from(endpointDispatch["githubEndpoint"]));
-              console.log("published github endpoint event");
+        newEndpointsWithKind.forEach((ep) => {
+          // const ep = JSON.parse(
+          //   endpoint.replace('url', '"url"').replace('kind', '"kind"'),
+          // );
+          const kind = ep.kind;
+          // if(kind == 'Github'){
+          //   endpointDispatch['githubEndpoint'].add(ep.url);
+          // }
+          if (kind == 'Docker') {
+            endpointDispatch['containerEndpoint'].add(ep.url);
+          } else if (kind == 'Database') {
+            // TODO
+          } else if (kind == 'EmailService') {
+            // TODO
+          } else if (kind == 'MessageBroker') {
+            // TODO
+          } else if (kind == 'CloudStorage') {
+            // TODO
+          }
+        });
 
-              githubEndpoints.clear()
-        
-              // TODO: anything under event collectors should not include any extra metadata beyond
-              // the URL itself, because any given event endpoint won't necessarily include info about
-              // what kind of other endpoitns its connected to.
-            }
-        }
-        catch(error){
-          console.log(error.message);
-        }
-        finally {
-        }
+        // // TODO :also graph relation updater needs to know how to figure out what kind of
+        // // url each endpoint is (e.g. github endpoint, web endpoint, etc.)
+        // for (let i = 0; i < queryResponse.endpoints.length; i++) {
+        //   //const endpointKinds = getEndpointKind(queryResponse.endpoints[i]["url"]);
+        //   for (let j = 0; j < endpointKinds.length; j++) {
+        //     if(endpointDispatch[endpointKinds[j]]){
+        //       endpointDispatch[endpointKinds[j]].push(queryResponse.endpoints[i]["url"]);
+        //     }
+        //   }
+        // }
+
+        console.log(endpointDispatch);
+
+        //Queue up new endpoints to be analyzed by the appropriate scanners
+        await publishToNats(
+          nc,
+          jc,
+          CONTAINER_ENDPOINT_QUEUE,
+          Array.from(endpointDispatch['containerEndpoint']),
+        );
+        console.log('published container endpoint events');
+        await publishToNats(
+          nc,
+          jc,
+          WEB_ENDPOINT_QUEUE,
+          Array.from(endpointDispatch['webEndpoint']),
+        );
+        console.log('published web endpoint events');
+        await publishToNats(
+          nc,
+          jc,
+          GITHUB_ENDPOINT_QUEUE,
+          Array.from(endpointDispatch['githubEndpoint']),
+        );
+        console.log('published github endpoint event');
+
+        githubEndpoints.clear();
+
+        // TODO: anything under event collectors should not include any extra metadata beyond
+        // the URL itself, because any given event endpoint won't necessarily include info about
+        // what kind of other endpoitns its connected to.
       }
+    } catch (error) {
+      console.log(error.message);
+    } finally {
+    }
+  }
 })();
 
 await nc.closed();

--- a/graph-updater/package-lock.json
+++ b/graph-updater/package-lock.json
@@ -13,7 +13,7 @@
         "fs-extra": "^11.2.0",
         "glob": "^10.4.5",
         "graphql": "^16.8.1",
-        "graphql-request": "^6.1.0",
+        "graphql-request": "^7.1.0",
         "js-yaml": "^4.1.0",
         "nats": "^2.16.0",
         "octokit": "3.1.2",
@@ -59,6 +59,32 @@
       "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
       "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
       "license": "MIT"
+    },
+    "node_modules/@molt/command": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@molt/command/-/command-0.9.0.tgz",
+      "integrity": "sha512-1JI8dAlpqlZoXyKWVQggX7geFNPxBpocHIXQCsnxDjKy+3WX4SGyZVJXuLlqRRrX7FmQCuuMAfx642ovXmPA9g==",
+      "dependencies": {
+        "@molt/types": "0.2.0",
+        "alge": "0.8.1",
+        "chalk": "^5.3.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.snakecase": "^4.1.1",
+        "readline-sync": "^1.4.10",
+        "string-length": "^6.0.0",
+        "strip-ansi": "^7.1.0",
+        "ts-toolbelt": "^9.6.0",
+        "type-fest": "^4.3.1",
+        "zod": "^3.22.2"
+      }
+    },
+    "node_modules/@molt/types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@molt/types/-/types-0.2.0.tgz",
+      "integrity": "sha512-p6ChnEZDGjg9PYPec9BK6Yp5/DdSrYQvXTBAtgrnqX6N36cZy37ql1c8Tc5LclfIYBNG7EZp8NBcRTYJwyi84g==",
+      "dependencies": {
+        "ts-toolbelt": "^9.6.0"
+      }
     },
     "node_modules/@octokit/app": {
       "version": "14.0.2",
@@ -563,6 +589,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/alge": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/alge/-/alge-0.8.1.tgz",
+      "integrity": "sha512-kiV9nTt+XIauAXsowVygDxMZLplZxDWt0W8plE/nB32/V2ziM/P/TxDbSVK7FYIUt2Xo16h3/htDh199LNPCKQ==",
+      "dependencies": {
+        "lodash.ismatch": "^4.4.0",
+        "remeda": "^1.0.0",
+        "ts-toolbelt": "^9.6.0",
+        "zod": "^3.17.3"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
@@ -627,6 +664,17 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
+    "node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -652,14 +700,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -798,15 +838,33 @@
       }
     },
     "node_modules/graphql-request": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
-      "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-7.1.0.tgz",
+      "integrity": "sha512-Ouu/lYVFhARS1aXeZoVJWnGT6grFJXTLwXJuK4mUGGRo0EUk1JkyYp43mdGmRgUVezpRm6V5Sq3t8jBDQcajng==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "cross-fetch": "^3.1.5"
+        "@molt/command": "^0.9.0",
+        "zod": "^3.23.8"
+      },
+      "bin": {
+        "graffle": "build/cli/generate.js"
       },
       "peerDependencies": {
+        "@dprint/formatter": "^0.3.0",
+        "@dprint/typescript": "^0.91.1",
+        "dprint": "^0.46.2",
         "graphql": "14 - 16"
+      },
+      "peerDependenciesMeta": {
+        "@dprint/formatter": {
+          "optional": true
+        },
+        "@dprint/typescript": {
+          "optional": true
+        },
+        "dprint": {
+          "optional": true
+        }
       }
     },
     "node_modules/indent-string": {
@@ -918,6 +976,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -932,6 +995,11 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+    },
+    "node_modules/lodash.ismatch": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
+      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g=="
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
@@ -952,6 +1020,11 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
     },
     "node_modules/lru-cache": {
       "version": "10.2.0",
@@ -1010,25 +1083,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/octokit": {
@@ -1102,6 +1156,19 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/remeda": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/remeda/-/remeda-1.61.0.tgz",
+      "integrity": "sha512-caKfSz9rDeSKBQQnlJnVW3mbVdFgxgGWQKq1XlFokqjf+hQD5gxutLGTTY2A/x24UxVyJe9gH5fAkFI63ULw4A=="
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -1193,6 +1260,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-6.0.0.tgz",
+      "integrity": "sha512-1U361pxZHEQ+FeSjzqRpV+cu2vTzYeWeafXFLykiFlv4Vc0n3njgU8HrMbyik5uwm77naWMuVG8fhEF+Ovb1Kg==",
+      "dependencies": {
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/string-width": {
@@ -1291,15 +1372,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    "node_modules/ts-toolbelt": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-9.6.0.tgz",
+      "integrity": "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
+    "node_modules/type-fest": {
+      "version": "4.26.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.26.1.tgz",
+      "integrity": "sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
@@ -1327,20 +1419,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -1458,6 +1536,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/graph-updater/package.json
+++ b/graph-updater/package.json
@@ -14,7 +14,7 @@
     "fs-extra": "^11.2.0",
     "glob": "^10.4.5",
     "graphql": "^16.8.1",
-    "graphql-request": "^6.1.0",
+    "graphql-request": "^7.1.0",
     "js-yaml": "^4.1.0",
     "nats": "^2.16.0",
     "octokit": "3.1.2",

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,142 +1,142 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-# - ./arangodeployment-single-server.yaml
-# - ./deployment-nats.yaml
-# - ./deployment-ruok-api.yaml
-# - ./deployment-webhook-server.yaml
-# - ./deployment-graph-updater.yaml
-# - ./deployment-octokit-scanner.yaml
-# - ./deployment-web-endpoint-scanner.yaml
-- ./deployment-cloned-repo-scanner.yaml
-# - ./svc-nats.yaml
-# - ./svc-ruok-api.yaml
-# - ./svc-webhook-server.yaml
-# - ./cron-job-dns-scanner.yaml
-# - ./ui-revived/deployment-ruok-ui.yaml
-# - ./ui-revived/svc-ruok-ui.yaml
-# - ./istio/gateway.yaml
-# - ./istio/v-svc-ruok-ui.yaml
+  - ./arangodeployment-single-server.yaml
+  - ./deployment-nats.yaml
+  - ./deployment-ruok-api.yaml
+  - ./deployment-webhook-server.yaml
+  - ./deployment-graph-updater.yaml
+  - ./deployment-octokit-scanner.yaml
+  - ./deployment-web-endpoint-scanner.yaml
+  - ./deployment-cloned-repo-scanner.yaml
+  - ./svc-nats.yaml
+  - ./svc-ruok-api.yaml
+  - ./svc-webhook-server.yaml
+  - ./cron-job-dns-scanner.yaml
+  - ./ui-revived/deployment-ruok-ui.yaml
+  - ./ui-revived/svc-ruok-ui.yaml
+  - ./istio/gateway.yaml
+  - ./istio/v-svc-ruok-ui.yaml
 patches:
-- target:
-    version: v1
-    kind: Deployment
-    name: graphql-api
-  patch: |-
-    - op: replace
-      path: /spec/template/spec/containers/0/image
-      value: northamerica-northeast2-docker.pkg.dev/phx-01h7dnj5j46f52sev8akqd9m7g/dockerimages/graphql-api:0.0.1
-    - op: add
-      path: /spec/template/spec/containers/0/env
-      value:
-        - name: DB_HOST
-          value: http://example-simple-single-ea:8529
-- target:
-    version: v1
-    kind: Deployment
-    name: webhook-server
-  patch: |-
-    - op: replace
-      path: /spec/template/spec/containers/0/image
-      value: vader404/ruok-webhook-server:0.0.1
-    - op: add
-      path: /spec/template/spec/containers/0/env
-      value:
-        - name: NATS_SERVER
-          value: nats:4222
-        - name: NATS_PUB_STREAM
-          value: EventsUpdate
-- target:
-    version: v1
-    kind: Deployment
-    name: graph-updater
-  patch: |-
-    - op: replace
-      path: /spec/template/spec/containers/0/image
-      value: northamerica-northeast2-docker.pkg.dev/phx-01h7dnj5j46f52sev8akqd9m7g/dockerimages/ruok-graph-updater:0.0.8
-    - op: add
-      path: /spec/template/spec/containers/0/env
-      value:
-        - name: NATS_URL
-          value: nats:4222
-        - name: GRAPHQL_URL
-          value: http://graphql-api:4000/graphql
-- target:
-    version: v1
-    kind: Deployment
-    name: cloned-repo-scanner
-  patch: |-
-    - op: replace
-      path: /spec/template/spec/containers/0/image
-      value: northamerica-northeast2-docker.pkg.dev/phx-01h7dnj5j46f52sev8akqd9m7g/dockerimages/ruok-cloned-repo-scanner:0.0.7
-    - op: add
-      path: /spec/template/spec/containers/0/env
-      value:
-        - name: NATS_URL
-          value: nats:4222
-        - name: GRAPHQL_URL
-          value: http://graphql-api:4000/graphql
-- target:
-    version: v1
-    kind: Deployment
-    name: octokit-scanner
-  patch: |-
-    - op: replace
-      path: /spec/template/spec/containers/0/image
-      value: vader404/ruok-octokit-scanner:0.0.2
-    - op: add
-      path: /spec/template/spec/containers/0/env
-      value:
-        - name: NATS_URL
-          value: nats:4222
-        - name: GRAPHQL_URL
-          value: http://graphql-api:4000/graphql
-- target:
-    version: v1
-    kind: Deployment
-    name: web-endpoint-scanner
-  patch: |-
-    - op: replace
-      path: /spec/template/spec/containers/0/image
-      value: vader404/ruok-web-endpoint-scanner:0.0.1
-    - op: add
-      path: /spec/template/spec/containers/0/env
-      value:
-        - name: NATS_URL
-          value: nats:4222
-        - name: GRAPHQL_URL
-          value: http://graphql-api:4000/graphql
-- target:
-    version: v1
-    kind: Deployment
-    name: ruok-ui
-  patch: |-
-    - op: replace
-      path: /spec/template/spec/containers/0/image
-      value: vader404/ruok-ui:0.0.1
-- target:
-    version: v1
-    kind: CronJob
-    name: dns-scanner
-  patch: |-
-    - op: replace
-      path: /spec/jobTemplate/spec/template/spec/containers/0/image
-      value: vader404/ruok-dns-scanner:0.0.8
-    - op: add
-      path: /spec/jobTemplate/spec/template/spec/containers/0/env
-      value:
-        - name: NATS_URL
-          value: nats:4222
-        - name: GRAPHQL_URL
-          value: http://graphql-api:4000/graphql
-        - name: DNS_REPOSITORY
-          value: https://github.com/PHACDataHub/phac-dns.git
-- target:
-    group: networking.istio.io
-    version: v1beta1
-    kind: Gateway
-    name: public-gateway
-  patch: |-
-    - op: add
-      path: /spec/servers/0/tls/httpsRedirect
-      value: false
+  - target:
+      version: v1
+      kind: Deployment
+      name: graphql-api
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: northamerica-northeast2-docker.pkg.dev/phx-01h7dnj5j46f52sev8akqd9m7g/dockerimages/graphql-api:0.0.1
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: DB_HOST
+            value: http://example-simple-single-ea:8529
+  - target:
+      version: v1
+      kind: Deployment
+      name: webhook-server
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: vader404/ruok-webhook-server:0.0.1
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: NATS_SERVER
+            value: nats:4222
+          - name: NATS_PUB_STREAM
+            value: EventsUpdate
+  - target:
+      version: v1
+      kind: Deployment
+      name: graph-updater
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: northamerica-northeast2-docker.pkg.dev/phx-01h7dnj5j46f52sev8akqd9m7g/dockerimages/ruok-graph-updater:0.0.1
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: NATS_URL
+            value: nats:4222
+          - name: GRAPHQL_URL
+            value: http://graphql-api:4000/graphql
+  - target:
+      version: v1
+      kind: Deployment
+      name: cloned-repo-scanner
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: northamerica-northeast2-docker.pkg.dev/phx-01h7dnj5j46f52sev8akqd9m7g/dockerimages/ruok-cloned-repo-scanner:0.0.2
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: NATS_URL
+            value: nats:4222
+          - name: GRAPHQL_URL
+            value: http://graphql-api:4000/graphql
+  - target:
+      version: v1
+      kind: Deployment
+      name: octokit-scanner
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: vader404/ruok-octokit-scanner:0.0.2
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: NATS_URL
+            value: nats:4222
+          - name: GRAPHQL_URL
+            value: http://graphql-api:4000/graphql
+  - target:
+      version: v1
+      kind: Deployment
+      name: web-endpoint-scanner
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: vader404/ruok-web-endpoint-scanner:0.0.1
+      - op: add
+        path: /spec/template/spec/containers/0/env
+        value:
+          - name: NATS_URL
+            value: nats:4222
+          - name: GRAPHQL_URL
+            value: http://graphql-api:4000/graphql
+  - target:
+      version: v1
+      kind: Deployment
+      name: ruok-ui
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/image
+        value: vader404/ruok-ui:0.0.1
+  - target:
+      version: v1
+      kind: CronJob
+      name: dns-scanner
+    patch: |-
+      - op: replace
+        path: /spec/jobTemplate/spec/template/spec/containers/0/image
+        value: vader404/ruok-dns-scanner:0.0.8
+      - op: add
+        path: /spec/jobTemplate/spec/template/spec/containers/0/env
+        value:
+          - name: NATS_URL
+            value: nats:4222
+          - name: GRAPHQL_URL
+            value: http://graphql-api:4000/graphql
+          - name: DNS_REPOSITORY
+            value: https://github.com/PHACDataHub/phac-dns.git
+  - target:
+      group: networking.istio.io
+      version: v1beta1
+      kind: Gateway
+      name: public-gateway
+    patch: |-
+      - op: add
+        path: /spec/servers/0/tls/httpsRedirect
+        value: false

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,22 +1,22 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ./arangodeployment-single-server.yaml
-- ./deployment-nats.yaml
-- ./deployment-ruok-api.yaml
-- ./deployment-webhook-server.yaml
-- ./deployment-graph-updater.yaml
-- ./deployment-octokit-scanner.yaml
-- ./deployment-web-endpoint-scanner.yaml
+# - ./arangodeployment-single-server.yaml
+# - ./deployment-nats.yaml
+# - ./deployment-ruok-api.yaml
+# - ./deployment-webhook-server.yaml
+# - ./deployment-graph-updater.yaml
+# - ./deployment-octokit-scanner.yaml
+# - ./deployment-web-endpoint-scanner.yaml
 - ./deployment-cloned-repo-scanner.yaml
-- ./svc-nats.yaml
-- ./svc-ruok-api.yaml
-- ./svc-webhook-server.yaml
-- ./cron-job-dns-scanner.yaml
-- ./ui-revived/deployment-ruok-ui.yaml
-- ./ui-revived/svc-ruok-ui.yaml
-- ./istio/gateway.yaml
-- ./istio/v-svc-ruok-ui.yaml
+# - ./svc-nats.yaml
+# - ./svc-ruok-api.yaml
+# - ./svc-webhook-server.yaml
+# - ./cron-job-dns-scanner.yaml
+# - ./ui-revived/deployment-ruok-ui.yaml
+# - ./ui-revived/svc-ruok-ui.yaml
+# - ./istio/gateway.yaml
+# - ./istio/v-svc-ruok-ui.yaml
 patches:
 - target:
     version: v1
@@ -25,7 +25,7 @@ patches:
   patch: |-
     - op: replace
       path: /spec/template/spec/containers/0/image
-      value: vader404/ruok-graphql-api:0.0.10
+      value: northamerica-northeast2-docker.pkg.dev/phx-01h7dnj5j46f52sev8akqd9m7g/dockerimages/graphql-api:0.0.1
     - op: add
       path: /spec/template/spec/containers/0/env
       value:
@@ -53,7 +53,7 @@ patches:
   patch: |-
     - op: replace
       path: /spec/template/spec/containers/0/image
-      value: vader404/ruok-graph-updater:0.0.3
+      value: northamerica-northeast2-docker.pkg.dev/phx-01h7dnj5j46f52sev8akqd9m7g/dockerimages/ruok-graph-updater:0.0.8
     - op: add
       path: /spec/template/spec/containers/0/env
       value:
@@ -68,7 +68,7 @@ patches:
   patch: |-
     - op: replace
       path: /spec/template/spec/containers/0/image
-      value: vader404/ruok-cloned-repo-scanner:0.0.4
+      value: northamerica-northeast2-docker.pkg.dev/phx-01h7dnj5j46f52sev8akqd9m7g/dockerimages/ruok-cloned-repo-scanner:0.0.7
     - op: add
       path: /spec/template/spec/containers/0/env
       value:

--- a/scanners/github-cloned-repo/index.js
+++ b/scanners/github-cloned-repo/index.js
@@ -57,7 +57,7 @@ process.on('SIGINT', () => process.exit(0))
 
                 console.log("===========================TESTING=======================")
 
-                console.log('Scan Results:',results)
+                // console.log('Scan Results:',results)
 
                 console.log("===========================TESTING 2=======================")
     

--- a/scanners/github-cloned-repo/index.js
+++ b/scanners/github-cloned-repo/index.js
@@ -1,148 +1,136 @@
 // github-has-dependabot-yaml-check/index.js
 
-import { connect, JSONCodec } from 'nats'
+import { connect, JSONCodec } from 'nats';
 
-import { initializeChecker } from './src/initialize-checker.js'
-import { cloneRepository, removeClonedRepository } from './src/clone-remove-repo.js'
-import { GraphQLClient, gql } from 'graphql-request'
-import 'dotenv-safe/config.js'
+import { initializeChecker } from './src/initialize-checker.js';
+import {
+  cloneRepository,
+  removeClonedRepository,
+} from './src/clone-remove-repo.js';
+import { GraphQLClient, gql } from 'graphql-request';
+import 'dotenv-safe/config.js';
 
-const {
-    NATS_URL,
-    GRAPHQL_URL,
-    NATS_SUB_STREAM,
-    GITHUB_TOKEN_CLASSIC
-} = process.env;
+const { NATS_URL, GRAPHQL_URL, NATS_SUB_STREAM, GITHUB_TOKEN_CLASSIC } =
+  process.env;
 
-
-// API connection 
+// API connection
 const graphQLClient = new GraphQLClient(GRAPHQL_URL);
 
-// NATs connection 
-const nc = await connect({ servers: NATS_URL, })
-const jc = JSONCodec()
+// NATs connection
+const nc = await connect({ servers: NATS_URL });
+const jc = JSONCodec();
 
-const sub = nc.subscribe(NATS_SUB_STREAM)
-console.log('🚀 Connected to NATS server - listening on ...', sub.subject, "channel...");
+const sub = nc.subscribe(NATS_SUB_STREAM);
+console.log(
+  '🚀 Connected to NATS server - listening on ...',
+  sub.subject,
+  'channel...',
+);
 
-process.on('SIGTERM', () => process.exit(0))
-process.on('SIGINT', () => process.exit(0))
-    ; (async () => {
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));
+(async () => {
+  for await (const message of sub) {
+    // decode payload
+    const gitHubEventPayload = await jc.decode(message.data);
 
-        for await (const message of sub) {
-            // decode payload 
-            const gitHubEventPayload = await jc.decode(message.data)
+    console.log(
+      `\n****************************** ${new Date()} ********************************`,
+    );
+    console.log(
+      `Recieved from ... ${message.subject}:\n ${JSON.stringify(gitHubEventPayload)}`,
+    );
 
-            console.log(`\n****************************** ${new Date()} ********************************`)
-            console.log(`Recieved from ... ${message.subject}:\n ${JSON.stringify(gitHubEventPayload)}`)
+    // GitHub urls always follow `github.com/orgName/repoName`, so from this
+    // structure we can construct the org name and repo name.
+    const prefix = new URL(gitHubEventPayload.endpoint).pathname.split('/');
+    const orgName = prefix[1];
+    const repoName = prefix[2];
 
-            // GitHub urls always follow `github.com/orgName/repoName`, so from this
-            // structure we can construct the org name and repo name.
-            const prefix = (new URL(gitHubEventPayload.endpoint)).pathname.split("/")
-            const orgName = prefix[1];
-            const repoName = prefix[2];
+    console.log('orgName', orgName);
+    console.log('repoName', repoName);
 
-            console.log('orgName', orgName)
-            console.log('repoName', repoName)
+    // Clone repository
+    try {
+      const repoPath = await cloneRepository(
+        gitHubEventPayload.endpoint,
+        repoName,
+        GITHUB_TOKEN_CLASSIC,
+      );
+      console.log('repoPath', repoPath, '\n');
 
-            // Clone repository
-            try{
-                const repoPath = await cloneRepository(gitHubEventPayload.endpoint, repoName, GITHUB_TOKEN_CLASSIC)
-                console.log ('repoPath', repoPath, '\n')
+      // Instantiate and do the check(s)
+      const checkName = 'allChecks';
+      const check = await initializeChecker(checkName, repoName, repoPath);
+      const results = await check.doRepoCheck();
+      // Mutation to add a graph for the new endpoints
+      // TODO: refactor this into a testable query builder function
 
-                // Instantiate and do the check(s)
-                const checkName = 'allChecks'
-                const check = await initializeChecker(checkName, repoName, repoPath)
-                const results = await check.doRepoCheck()
-
-                console.log("===========================TESTING=======================")
-
-                // console.log('Scan Results:',results)
-
-                console.log("===========================TESTING 2=======================")
-    
-                // Mutation to add a graph for the new endpoints
-                // TODO: refactor this into a testable query builder function
-
-                // TODO: figure out why this only works with 'trivyRepoVulnerability', where it's coded as 'trivy_repo_vulnerability'
-                //      in api, etc
-                const mutation = gql`
-                mutation {
-                    githubEndpoint(
-                        endpoint: {
-                            url: "${gitHubEventPayload.endpoint}"
-                            kind: "Github"
-                            owner: "${orgName}"
-                            repo: "${repoName}"
-                            api: ${results.hasApiDirectory.checkPasses}                       
-                            hasSecurityMd: {
-                                checkPasses: ${results.hasSecurityMd.checkPasses}
-                                metadata: ${results.hasSecurityMd.metadata}
-                            },
-                            hasDependabotYaml: {
-                                checkPasses: ${results.hasDependabotYaml.checkPasses}
-                                metadata: ${results.hasDependabotYaml.metadata}
-                            },
-                            gitleaks: {
-                                checkPasses: ${results.gitleaks ? results.gitleaks.checkPasses : null}
-                                metadata: ${results.gitleaks ? JSON.stringify(results.gitleaks.metadata, null, 4).replace(/"([^"]+)":/g, '$1:') : {}}
-                            },
-                            hadolint: {
-                                checkPasses: ${results.hadolint ? results.hadolint.checkPasses : null}
-                                metadata: ${JSON.stringify(results.hadolint.metadata, null, 4).replace(/"([^"]+)":/g, '$1:')}
-                            }
-                            trivyRepoVulnerability: {
-                                checkPasses: ${results.trivy_repo_vulnerability ? results.trivy_repo_vulnerability.checkPasses : null}
-
-                                metadata: ${results.trivy_repo_vulnerability && results.trivy_repo_vulnerability.metadata !== undefined ?
-                                    JSON.stringify(results.trivy_repo_vulnerability.metadata, null, 4).replace(/"([^"]+)":/g, '$1:') :
-                                    null
-                                }
-                            }                       
-                        }
-                    )
-                }`;
-                //console.log('*************************\n',mutation,'\n*************************\n')
-        
-                // New GraphQL client - TODO: remove hard-coded URL
-                try {
-                    const graphqlClient = new GraphQLClient(GRAPHQL_URL);
-
-                    // Write mutation to GraphQL API
-                    const mutationResponse = await graphqlClient.request(mutation);
-                    console.log('Scan results saved to database.')
-
-                } catch (error) {
-                    console.error("An error occurred - unable to save to the database.", error);
-                }
-                
-                // Remove temp repository
-                await removeClonedRepository(repoPath)
+      // TODO: figure out why this only works with 'trivyRepoVulnerability', where it's coded as 'trivy_repo_vulnerability'
+      //      in api, etc
+      const mutation = gql`
+        mutation addGraph(
+          $url: String!
+          $owner: String!
+          $repo: String!
+          $api: Boolean!
+          $hasSecurityMd: CheckPassesInput
+          $hasDependabotYaml: CheckPassesInput
+          $gitleaks: CheckPassesInput
+          $hadolint: CheckPassesInput
+          $trivyRepoVulnerability: CheckPassesInput
+        ) {
+          githubEndpoint(
+            endpoint: {
+              url: $url
+              kind: "Github"
+              owner: $owner
+              repo: $repo
+              api: $api
+              hasSecurityMd: $hasSecurityMd
+              hasDependabotYaml: $hasDependabotYaml
+              gitleaks: $gitleaks
+              hadolint: $hadolint
+              trivyRepoVulnerability: $trivyRepoVulnerability
             }
-            catch(error){
-                                    
-            }
-            
+          )
         }
-    })();
+      `;
+
+      const variables = {
+        url: gitHubEventPayload.endpoint,
+        owner: orgName,
+        repo: repoName,
+        api: results.hasApiDirectory.checkPasses,
+        hasSecurityMd: results.hasSecurityMd,
+        hasDependabotYaml: results.hasDependabotYaml,
+        gitleaks: results.gitleaks,
+        hadolint: results.hadolint,
+        trivyRepoVulnerability: results.trivy_repo_vulnerability,
+      };
+      //console.log('*************************\n',mutation,'\n*************************\n')
+
+      // New GraphQL client - TODO: remove hard-coded URL
+      try {
+        const graphqlClient = new GraphQLClient(GRAPHQL_URL);
+
+        // Write mutation to GraphQL API
+        const mutationResponse = await graphqlClient.request(
+          mutation,
+          variables,
+        );
+        console.log('Scan results saved to database.');
+      } catch (error) {
+        console.error(
+          'An error occurred - unable to save to the database.',
+          error,
+        );
+      }
+
+      // Remove temp repository
+      await removeClonedRepository(repoPath);
+    } catch (error) {}
+  }
+})();
 
 await nc.closed();
-
-// nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/ruok-service-autochecker\"}"
-// nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/acm-core\"}"
-// nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/it33-filtering\"}"
-
-// nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/phac-bots\"}"
-// nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/pelias-canada\"}"
-// nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/safe-inputs\"}"
-// nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/data-catalog\"}"
-
-
-// nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/cpho-phase2\"}"
-
-// nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/phac-bots\"}"
-
-// nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/phac-dns\"}" 
-
-// nats pub "EventsScanner.githubEndpoints" "{\"endpoint\":\"https://github.com/PHACDataHub/django-phac_aspc-helpers\"}" 
-

--- a/ui/src/components/Service.jsx
+++ b/ui/src/components/Service.jsx
@@ -1,6 +1,15 @@
 import { React, useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { Flex, Box, Text, Heading, DataList, Spinner, Separator, Select } from '@radix-ui/themes';
+import {
+  Flex,
+  Box,
+  Text,
+  Heading,
+  DataList,
+  Spinner,
+  Separator,
+  Select,
+} from '@radix-ui/themes';
 import { DoubleArrowRightIcon } from '@radix-ui/react-icons';
 import CheckPasses from './CheckPasses';
 import { useQuery, NetworkStatus } from '@apollo/client';
@@ -12,9 +21,9 @@ import {
 
 const Service = () => {
   const { serviceName } = useParams();
-  const [ uptime,setUptime ] = useState([]);
-  const [ responseTimeKind,setResponseTimeKind ] = useState(2);
-  const [ uptimeKind,setUptimeKind ] = useState(2);
+  const [uptime, setUptime] = useState([]);
+  const [responseTimeKind, setResponseTimeKind] = useState(2);
+  const [uptimeKind, setUptimeKind] = useState(2);
   const { data, loading, error, networkStatus } = useQuery(
     FETCH_SERVICE_QUERY,
     {
@@ -36,46 +45,62 @@ const Service = () => {
   const fetchUptime = () => {
     let doc = '';
     let data = [];
-    let respTimeMap = { 0 : "", 1 : "-day", 2 : "-week", 3 : "-month", 4 : "-year"};
-    fetch('/uptime',{mode: "cors",referrerPolicy: "unsafe-url"}).then(function (response) {
+    let respTimeMap = { 0: '', 1: '-day', 2: '-week', 3: '-month', 4: '-year' };
+    fetch('/uptime', { mode: 'cors', referrerPolicy: 'unsafe-url' })
+      .then(function (response) {
         // The API call was successful!
         return response.text();
-      }).then(function (html) {
-
+      })
+      .then(function (html) {
         // Convert the HTML string into a document object
         let parser = new DOMParser();
-        doc =  parser.parseFromString(html, 'text/html');
-        let trs = doc.getElementsByTagName("table")[1].tBodies[0].getElementsByTagName("tr");
+        doc = parser.parseFromString(html, 'text/html');
+        let trs = doc
+          .getElementsByTagName('table')[1]
+          .tBodies[0].getElementsByTagName('tr');
         console.log(trs);
-        Array.prototype.slice.call(trs).forEach(tr => {
-            let statusString = tr.children[1].innerText;
-            let serviceName = tr.children[2].innerText.split(/\.y.*ml/)[0];
-            let responseTimes = [];
-            let upTimes = [];
-            let url = `https://raw.githubusercontent.com/niranjan-ramesh/upptime/master/graphs/${serviceName}/response-time`;
-            for(let idx = 1;idx <= 5;idx++){
-              let responseTime = tr.children[3].getElementsByTagName("a")[idx].firstChild.alt.split(" ").slice(-1)[0]; 
-              responseTimes.push([responseTime,url+respTimeMap[idx-1]+'.png']);
-              let upTime = tr.children[4].getElementsByTagName("a")[idx].firstChild.alt.split(" ").slice(-1)[0]; 
-              upTimes.push(upTime);
-            }
-            // console.table(statusString,serviceName,responseTimes);
-            data.push([statusString,serviceName,responseTimes,upTimes]);
+        Array.prototype.slice.call(trs).forEach((tr) => {
+          let statusString = tr.children[1].innerText;
+          let serviceName = tr.children[2].innerText.split(/\.y.*ml/)[0];
+          let responseTimes = [];
+          let upTimes = [];
+          let url = `https://raw.githubusercontent.com/niranjan-ramesh/upptime/master/graphs/${serviceName}/response-time`;
+          for (let idx = 1; idx <= 5; idx++) {
+            let responseTime = tr.children[3]
+              .getElementsByTagName('a')
+              [idx].firstChild.alt.split(' ')
+              .slice(-1)[0];
+            responseTimes.push([
+              responseTime,
+              url + respTimeMap[idx - 1] + '.png',
+            ]);
+            let upTime = tr.children[4]
+              .getElementsByTagName('a')
+              [idx].firstChild.alt.split(' ')
+              .slice(-1)[0];
+            upTimes.push(upTime);
+          }
+          // console.table(statusString,serviceName,responseTimes);
+          data.push([statusString, serviceName, responseTimes, upTimes]);
         });
-        let uptimeData = data.filter(el => el[1] === serviceName);
-        console.log(uptimeData)
+        let uptimeData = data.filter((el) => el[1] === serviceName);
+        console.log(uptimeData);
         setUptime((prevUptime) => uptimeData);
-      }).catch(function (err) {
+      })
+      .catch(function (err) {
         // There was an error
         console.warn('Something went wrong.', err);
       });
-  }
+  };
 
   useEffect(() => {
-      fetchUptime();
-      const interval = setInterval(() => {
+    fetchUptime();
+    const interval = setInterval(
+      () => {
         fetchUptime();
-      }, 5 * 60 * 1000);
+      },
+      5 * 60 * 1000,
+    );
     return () => clearInterval(interval);
   }, []);
 
@@ -93,7 +118,6 @@ const Service = () => {
   if (!service) {
     return <Text>The service could not be found.</Text>;
   }
-
 
   return (
     <Box style={{ padding: '24px' }}>
@@ -139,8 +163,8 @@ const Service = () => {
                 >
                   {service.webEndpoint.url}
                 </Link>
-                <Separator  orientation="vertical"/>
-                {uptime.length > 0 ? uptime[0][0] : "NA"}
+                <Separator orientation="vertical" />
+                {uptime.length > 0 ? uptime[0][0] : 'NA'}
               </Flex>
             </DataList.Value>
           </DataList.Item>
@@ -195,17 +219,28 @@ const Service = () => {
                   to={`https://niranjan-ramesh.github.io/upptime/history/${serviceName}`}
                   style={{ color: 'blue', textDecoration: 'underline' }}
                 >
-                  <img height="50" src={uptime.length > 0 ? uptime[0][2][responseTimeKind][1] : ""}></img>
+                  <img
+                    height="50"
+                    src={
+                      uptime.length > 0 ? uptime[0][2][responseTimeKind][1] : ''
+                    }
+                  ></img>
                 </Link>
-                <Separator  orientation="vertical"/>
+                <Separator orientation="vertical" />
                 <Link
                   to={`https://niranjan-ramesh.github.io/upptime/history/${serviceName}`}
                   style={{ color: 'blue', textDecoration: 'underline' }}
                 >
-                  {uptime.length > 0 ? uptime[0][2][responseTimeKind][0]+'ms' : "NA"}
+                  {uptime.length > 0
+                    ? uptime[0][2][responseTimeKind][0] + 'ms'
+                    : 'NA'}
                 </Link>
-                <Separator  orientation="vertical"/>
-                <Select.Root size="2" defaultValue="2" onValueChange={(e) => setResponseTimeKind(Number(e))}>
+                <Separator orientation="vertical" />
+                <Select.Root
+                  size="2"
+                  defaultValue="2"
+                  onValueChange={(e) => setResponseTimeKind(Number(e))}
+                >
                   <Select.Trigger />
                   <Select.Content>
                     <Select.Item value="1">Day</Select.Item>
@@ -227,10 +262,14 @@ const Service = () => {
                   to={`https://niranjan-ramesh.github.io/upptime/history/${serviceName}`}
                   style={{ color: 'blue', textDecoration: 'underline' }}
                 >
-                  {uptime.length > 0 ? uptime[0][3][uptimeKind] : "NA"}
+                  {uptime.length > 0 ? uptime[0][3][uptimeKind] : 'NA'}
                 </Link>
-                <Separator  orientation="vertical"/>
-                <Select.Root size="2" defaultValue="2" onValueChange={(e) => setUptimeKind(Number(e))}>
+                <Separator orientation="vertical" />
+                <Select.Root
+                  size="2"
+                  defaultValue="2"
+                  onValueChange={(e) => setUptimeKind(Number(e))}
+                >
                   <Select.Trigger />
                   <Select.Content>
                     <Select.Item value="1">Day</Select.Item>
@@ -270,9 +309,10 @@ const Service = () => {
                       backgroundColor: '#f0f0f0',
                       borderRadius: '8px',
                       boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+                      wordWrap: 'break-word',
                     }}
                   >
-                    <Text>{endpoint.url}</Text>
+                    <Text style={{ maxWidth: '100%' }}>{endpoint.url}</Text>
                     <DoubleArrowRightIcon />
                   </Flex>
                 </Link>


### PR DESCRIPTION
- Fix graphql-api id generation for ArrangoDB.
- Disable pushing all github end points back to queue to start scanning. Random git repositories (eg: some of Google's) mentioned in the codebases getting scanned. Currently I don't think there are packages/references used from other internal git repos. Trivy/other vulnerability scans should pick issues in the ones used.
- Correcting some mutations to ensure that variables are passed instead of formatting strings. (Still left to finish).
- Use docker images from Google Artifact registry for modified services.
- Use max-width for Referencing end points section in UI so long strings don't break page layout.
- Formatter run on modified files. 